### PR TITLE
Fix issue with widget without widget_map

### DIFF
--- a/Resolver/WidgetSearchContentResolver.php
+++ b/Resolver/WidgetSearchContentResolver.php
@@ -112,7 +112,7 @@ class WidgetSearchContentResolver extends BaseWidgetContentResolver
                             $_result = $_result->getResult();
 
                             if ($_result->getScore() > 0.4) {
-                                if ($_entity instanceof Widget) {
+                                if ($_entity instanceof Widget && null !== $_entity->getWidgetMap()) {
                                     $view = $_entity->getWidgetMap()->getView();
                                     if ($this->isPageAccessible($view)) {
                                         if (!in_array($view->getId(), $alreadyAdded) && !$view instanceof Template) {


### PR DESCRIPTION
Fix exception that resulted in a error page with the text:

> 503 Service Unavailable

Here is the root of the error:

> FatalThrowableError in WidgetSearchContentResolver.php line 116:
> Call to a member function getView() on null

We have some projects with orphan widgets, in other words their `widget_map_id` value is null.

With this condition, widgets without widget map will be ignored.