### PR TITLE
Allow Victoire 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "victoire/victoire": "~2.3 | ~3.0",
+        "victoire/victoire": "~2.2 | ~3.0",
         "jms/serializer-bundle": "^1.0",
         "friendsofsymfony/elastica-bundle": "^3.1"
     },


### PR DESCRIPTION
Don't block installation on Victoire 2.2.